### PR TITLE
Modify RO cooperation for task 5

### DIFF
--- a/Handbook/Handbook.md
+++ b/Handbook/Handbook.md
@@ -365,7 +365,7 @@ You are **not**, under any circumstances, allowed to;
 
 You are allowed to warn employees if they attempt to grief the duties of the Reactor Operators. You may give warnings whenever they attempt to interfere with the current task, or if they are preventing/impeding the efforts of Reactor Operators to reach current task parameters.
 
-After 6 AM you are allowed to aid the reactor shutdown process for Task 5 if all other tasks are complete/the Reactor Operators vote to.
+After 6 AM you are allowed to aid the reactor shutdown process for Task 5 if all other tasks are completed (failed tasks count as completed) or if the Reactor Operators vote to.
 
 You must warn an employee a total of 3 Times before terminating them.
 - If an employee has been warned, and the task they were warned in was completed, the warnings carry over to the next task.

--- a/Handbook/Section 3 - Operations/3.5 RO Cooperation.md
+++ b/Handbook/Section 3 - Operations/3.5 RO Cooperation.md
@@ -6,7 +6,7 @@
 
 You are allowed to warn employees if they attempt to grief the duties of the Reactor Operators. You may give warnings whenever they attempt to interfere with the current task, or if they are preventing/impeding the efforts of Reactor Operators to reach current task parameters.
 
-After 6 AM you are allowed to aid the reactor shutdown process for Task 5 if all other tasks are complete/the Reactor Operators vote to.
+After 6 AM you are allowed to aid the reactor shutdown process for Task 5 if all other tasks are completed (failed tasks count as completed) or if the Reactor Operators vote to.
 
 You must warn an employee a total of 3 Times before terminating them.
 - If an employee has been warned, and the task they were warned in was completed, the warnings carry over to the next task.


### PR DESCRIPTION
I changed the rule for task 5 cooperation so failed tasks count as completed (so for example if tasks 1, 2 and 3 are completed but task 4 is failed, you can still help with task 5). This changes the rule so I will wait for PC+ feedback before merging to staging.